### PR TITLE
Copter: fix compile error due to pos_control chnage in syntax

### DIFF
--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -64,7 +64,7 @@ void Copter::update_land_detector()
         // because multi's use throttle), check that collective pitch is below mid collective (zero thrust) position.  For modes 
         // that use altitude hold, check that the pilot is commanding a descent and collective is at min allowed for altitude hold modes.
         bool motor_at_lower_limit = ((flightmode->has_manual_throttle() && motors->get_below_mid_collective() && fabsf(ahrs.get_roll()) < M_PI/2.0f) 
-                                    || (motors->limit.throttle_lower && pos_control->get_vel_desired_cms().z < 0.0f));
+                                    || (motors->limit.throttle_lower && pos_control->get_desired_velocity().z < 0.0f));
 #else
         // check that the average throttle output is near minimum (less than 12.5% hover throttle)
         bool motor_at_lower_limit = motors->limit.throttle_lower && attitude_control->is_throttle_mix_min();


### PR DESCRIPTION
Fixes compile error due to syntax difference between 4.0 and 4.1 which original commit was built from. 